### PR TITLE
removed unregistration of autoloaders other than composer

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -71,10 +71,10 @@ class Loader
 
         //unregister composer
         $loaders = spl_autoload_functions();
-        foreach ($loaders as $loader) {
-	    // we need to replace only composer
-            if(is_array($loader) && $loader[0] instanceof ClassLoader) {
-                spl_autoload_unregister($loader);
+        foreach ($loaders as $l) {
+            // we need to replace only composer
+            if (is_array($l) && $l[0] instanceof ClassLoader) {
+                spl_autoload_unregister($l);
             }
         }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -72,7 +72,10 @@ class Loader
         //unregister composer
         $loaders = spl_autoload_functions();
         foreach ($loaders as $loader) {
-            spl_autoload_unregister($loader);
+	    // we need to replace only composer
+            if(is_array($loader) && $loader[0] instanceof ClassLoader) {
+                spl_autoload_unregister($loader);
+            }
         }
 
         //register wrapper


### PR DESCRIPTION
There was a problem working with Sympfony, when used Swift mailer: Swift's autoloader does not calls due to unload.
